### PR TITLE
feat: '/forgotpassword' 페이지 ui

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,20 +7,21 @@ import NotFound from '@/routes/NotFound';
 import Login from './routes/Login';
 import SignUp from './routes/SignUp';
 import Kakao from './routes/Kakao';
+import ForgotPassword from './routes/ForgotPassword';
 
 export default function App() {
   return (
     <Routes>
       <Route element={<Layout />}>
         <Route path="/" element={<Home />} />
-
         <Route path="/auth/kakao/callback" element={<Kakao />} />
         {/* not found */}
         <Route path="/*" element={<NotFound />} />
       </Route>
-      {/* 로그인 회원가입은 Navbar, Footer 없이 */}
+      {/* 로그인, 회원가입은 Navbar, Footer 없이 */}
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<SignUp />} />
+      <Route path="/forgotpassword" element={<ForgotPassword />} />
       <Route element={<AdminLayout />}>
         <Route path="/admin/survey" element={<AdminSurvey />} />
       </Route>

--- a/src/index.css
+++ b/src/index.css
@@ -28,7 +28,3 @@
     transform: rotate(360deg);
   }
 }
-
-.login_bg {
-  background-image: url('/public/login.jpg');
-}

--- a/src/routes/ForgotPassword.tsx
+++ b/src/routes/ForgotPassword.tsx
@@ -54,7 +54,7 @@ export default function ForgotPassword() {
           <Popple />
         </div>
         <Title text="비밀번호를 잊으셨나요?" />
-        <p className="text-subTextAndBorder dark:text-gray-400">
+        <p className="text-sm text-subTextAndBorder dark:text-gray-400">
           이메일을 입력해주시면 <br />
           비밀번호를 재설정하는 링크를 보내드릴게요.
         </p>

--- a/src/routes/ForgotPassword.tsx
+++ b/src/routes/ForgotPassword.tsx
@@ -1,0 +1,82 @@
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import Popple from '@/components/ui/Popple';
+import Title from '@/components/ui/Title';
+import ValidationMessage from '@/components/ui/ValidationMessage';
+import { EMAIL_REGEX } from '@/data/constants';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+export default function ForgotPassword() {
+  const [emailInput, setEmailInput] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | null>(null);
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      setTimeoutId(null);
+    }
+
+    if (emailInput.trim()) {
+      setMessage('이메일을 입력해주세요');
+      const id = setTimeout(() => {
+        setMessage('');
+      }, 2000);
+      setTimeoutId(id);
+      return;
+    }
+    if (!EMAIL_REGEX.test(emailInput)) {
+      setMessage('올바른 이메일을 입력해주세요');
+      const id = setTimeout(() => {
+        setMessage('');
+      }, 2000);
+      setTimeoutId(id);
+      return;
+    }
+    console.log(emailInput);
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setEmailInput(event.target.value);
+  };
+
+  return (
+    <div className="flex h-screen items-center justify-center bg-slate-100">
+      <form
+        className="flex w-5/6 flex-col gap-1 rounded-md bg-white p-5 shadow-sm sm:w-[600px] sm:gap-4"
+        onSubmit={handleSubmit}
+      >
+        <div className="mx-auto w-32">
+          <Popple />
+        </div>
+        <Title text="비밀번호를 잊으셨나요?" />
+        <p className="text-subTextAndBorder dark:text-gray-400">
+          이메일을 입력해주시면 <br />
+          비밀번호를 재설정하는 링크를 보내드릴게요.
+        </p>
+
+        <div>
+          <Input
+            onChange={handleChange}
+            value=""
+            label="등록한 이메일"
+            name="email"
+          />
+        </div>
+        <ValidationMessage message={message} />
+
+        <Button contents={'비밀번호 재설정'} submit />
+        <p className="mt-3 text-xs text-subTextAndBorder">
+          비밀번호가 생각이 나셨나요?{' '}
+          <Link to="/login" className="transition hover:text-black">
+            로그인
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -123,7 +123,7 @@ export default function Login() {
           </p>
           <p className="mt-3 text-xs text-subTextAndBorder">
             비밀번호를 잊으셨나요?{' '}
-            <Link to="/findpassword" className="transition hover:text-black">
+            <Link to="/forgotpassword" className="transition hover:text-black">
               비밀번호 찾기
             </Link>
           </p>


### PR DESCRIPTION
## ✨ 기능명
<img width="625" alt="image" src="https://github.com/FastSubTeam/front/assets/87072568/92bf81a1-5cd5-4ab1-b7d6-dfdd4746923a">
<img width="275" alt="image" src="https://github.com/FastSubTeam/front/assets/87072568/59307f64-d1e6-406c-8d56-b257c950ca09">


### 📝 작업내용
- '/forgotpassword' 페이지 ui

### 🐞 관련 이슈
#29 

### 궁금한 사항 또는 공유할 사항
- ui만 작업하고 통신은 구현하지 않았습니다.