### PR TITLE
Feat: 전체 이벤트 검색 조회 메뉴바 생성

### DIFF
--- a/src/components/events/EventList.tsx
+++ b/src/components/events/EventList.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { dummyEventsData } from '@/types/IEvents';
 import Pagination from '@mui/material/Pagination';
 import EventLayout from '@/components/EventLayout';
+import { COUNT_PER_EVENTS_PAGE } from '@/data/constants';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 export default function EventList() {
@@ -10,18 +11,17 @@ export default function EventList() {
   const [page, setPage] = useState(1); // 페이지 번호
 
   const numOfEvent = dummyEventsData.length; // 등록된 이벤트의 개수
-  const eventsPerPage = 12; // 헌 페이지 당 노출시킬 event의 개수
-  const totalPages = Math.ceil(numOfEvent / eventsPerPage); // 총 페이지의 수
-  const startIdx = (page - 1) * eventsPerPage; // 이벤트 데이터 내 idx
+  const totalPages = Math.ceil(numOfEvent / COUNT_PER_EVENTS_PAGE); // 총 페이지의 수
+  const startIdx = (page - 1) * COUNT_PER_EVENTS_PAGE; // 이벤트 데이터 내 idx
   const displayedEvents = dummyEventsData.slice(
     startIdx,
-    startIdx + eventsPerPage,
+    startIdx + COUNT_PER_EVENTS_PAGE,
   );
   const listTitle = isSearched ? `${numOfEvent}개의 이벤트` : '행사 리스트'; // 판매자 로그인 때, 비 로그인 & 일반 유저일 때의 title
 
   // page button click에 따른 현재 페이지 번호 핸들링
   const handlePagination = (
-    event: React.ChangeEvent<unknown>,
+    _event: React.ChangeEvent<unknown>,
     value: number,
   ) => {
     setPage(value);

--- a/src/components/events/EventSearchBar.tsx
+++ b/src/components/events/EventSearchBar.tsx
@@ -1,0 +1,189 @@
+import { useRecoilState } from 'recoil';
+import { Listbox } from '@headlessui/react';
+import { AiOutlineDown } from 'react-icons/ai';
+import { AdressState } from '@/states/AdressState';
+import {
+  EVENT_REGION_ITEMS,
+  EVENT_STATE_ITEMS,
+  EVENT_CATEGORY_ITEMS,
+} from '@/data/address';
+
+export default function EventSearchBar() {
+  // 선택된 지역 state
+  const [selected, setSelected] = useRecoilState(AdressState);
+
+  // 선택된 지역에 따른 시-군-구 filtering
+  const filteredStates = EVENT_STATE_ITEMS.filter(
+    (state) => state[selected.region as string],
+  );
+
+  // region을 업데이트하기 위한 이벤트 핸들러
+  const handleRegionChange = (value: string) => {
+    setSelected((prev) => ({
+      ...prev,
+      region: Object.values<string>(value)[0],
+    }));
+  };
+
+  // state를 업데이트하기 위한 이벤트 핸들러
+  const handleStateChange = (value: string) => {
+    setSelected((prev) => ({
+      ...prev,
+      state: Object.values<string>(value)[0],
+    }));
+  };
+
+  // category를 업데이트하기 위한 이벤트 핸들러
+  const handleCategoryChange = (value: string) => {
+    setSelected((prev) => ({
+      ...prev,
+      category: Object.values<string>(value)[0],
+    }));
+  };
+
+  return (
+    <div className="ml-6 flex w-full gap-2 sm:ml-36 sm:gap-4">
+      {/* 드롭다운 버튼 - region */}
+      <Listbox value={selected.region} onChange={handleRegionChange}>
+        <div className="relative mt-4 ">
+          <Listbox.Button className="relative cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:w-[12rem] sm:text-sm">
+            {/* 드롭다운 메뉴 이름 */}
+            <span className="block truncate">{selected.region}</span>
+            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+              {/* 드롭다운 아이콘 */}
+              <div
+                className="max h-5 w-5 text-center text-xl text-gray-400"
+                aria-hidden="true"
+              >
+                <AiOutlineDown />
+              </div>
+            </span>
+          </Listbox.Button>
+
+          {/* 드롭다운 목록 */}
+          <Listbox.Options className="absolute z-10 mt-1 max-h-[25rem] w-[10rem] gap-2 overflow-auto bg-white py-1 text-center text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:w-full sm:text-sm">
+            <div className=" grid grid-cols-2 rounded-lg">
+              {EVENT_REGION_ITEMS.map((value, index) => (
+                <Listbox.Option
+                  key={index}
+                  className={({ active }) =>
+                    `relative grid cursor-pointer select-none px-2 py-4 ${
+                      active
+                        ? 'rounded-lg bg-accent text-white'
+                        : 'text-gray-900'
+                    }`
+                  }
+                  value={value}
+                >
+                  {({ selected }) => (
+                    <span
+                      className={`block  ${
+                        selected ? 'font-medium' : 'font-normal'
+                      }`}
+                    >
+                      {value.region}
+                    </span>
+                  )}
+                </Listbox.Option>
+              ))}
+            </div>
+          </Listbox.Options>
+        </div>
+      </Listbox>
+
+      {/* 드롭다운 버튼 - state */}
+      <Listbox value={selected.state} onChange={handleStateChange}>
+        <div className="relative mt-4 ">
+          <Listbox.Button className="relative cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:w-[12rem] sm:text-sm">
+            <span className="block truncate">{selected.state}</span>
+            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+              {/* 드롭다운 아이콘 */}
+              <div
+                className="max h-5 w-5 text-center text-xl text-gray-400"
+                aria-hidden="true"
+              >
+                <AiOutlineDown />
+              </div>
+            </span>
+          </Listbox.Button>
+
+          {/* 드롭다운 목록 */}
+          <Listbox.Options className="absolute z-10 mt-1 max-h-[25rem] w-[10rem] gap-2 overflow-auto bg-white  py-1 text-center text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:w-full sm:text-sm">
+            <div className=" grid grid-cols-2 rounded-lg">
+              {filteredStates.map((value, index) => (
+                <Listbox.Option
+                  key={index}
+                  className={({ active }) =>
+                    `relative grid cursor-pointer select-none px-2 py-4 ${
+                      active
+                        ? 'rounded-lg bg-accent text-white'
+                        : 'text-gray-900'
+                    }`
+                  }
+                  value={value}
+                >
+                  {({ selected }) => (
+                    <span
+                      className={`block  ${
+                        selected ? 'font-medium' : 'font-normal'
+                      }`}
+                    >
+                      {Object.values(value)}
+                    </span>
+                  )}
+                </Listbox.Option>
+              ))}
+            </div>
+          </Listbox.Options>
+        </div>
+      </Listbox>
+
+      {/* 드롭다운 버튼 - category */}
+      <Listbox value={selected.category} onChange={handleCategoryChange}>
+        <div className="relative mt-4 ">
+          <Listbox.Button className="relative cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:w-[12rem] sm:text-sm">
+            <span className="block truncate">{selected.category}</span>
+            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+              {/* 드롭다운 아이콘 */}
+              <div
+                className="max h-5 w-5 text-center text-xl text-gray-400"
+                aria-hidden="true"
+              >
+                <AiOutlineDown />
+              </div>
+            </span>
+          </Listbox.Button>
+
+          {/* 드롭다운 목록 */}
+          <Listbox.Options className="absolute z-10 mt-1 max-h-[25rem] w-[10rem] gap-2 overflow-auto bg-white py-1 text-center text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:w-full sm:text-sm">
+            <div className=" grid grid-cols-2 rounded-lg">
+              {EVENT_CATEGORY_ITEMS.map((value, index) => (
+                <Listbox.Option
+                  key={index}
+                  className={({ active }) =>
+                    `relative grid cursor-pointer select-none px-2 py-4 ${
+                      active
+                        ? 'rounded-lg bg-accent text-white'
+                        : 'text-gray-900'
+                    }`
+                  }
+                  value={value}
+                >
+                  {({ selected }) => (
+                    <span
+                      className={`block  ${
+                        selected ? 'font-medium' : 'font-normal'
+                      }`}
+                    >
+                      {Object.values(value)}
+                    </span>
+                  )}
+                </Listbox.Option>
+              ))}
+            </div>
+          </Listbox.Options>
+        </div>
+      </Listbox>
+    </div>
+  );
+}

--- a/src/components/events/EventSearchBar.tsx
+++ b/src/components/events/EventSearchBar.tsx
@@ -1,7 +1,8 @@
-import { useRecoilState } from 'recoil';
 import { Listbox } from '@headlessui/react';
+import { HiArrowPath } from 'react-icons/hi2';
 import { AiOutlineDown } from 'react-icons/ai';
 import { AdressState } from '@/states/AdressState';
+import { useRecoilState, useResetRecoilState } from 'recoil';
 import {
   EVENT_REGION_ITEMS,
   EVENT_STATE_ITEMS,
@@ -9,6 +10,8 @@ import {
 } from '@/data/address';
 
 export default function EventSearchBar() {
+  const resetList = useResetRecoilState(AdressState);
+
   // 선택된 지역 state
   const [selected, setSelected] = useRecoilState(AdressState);
 
@@ -42,148 +45,159 @@ export default function EventSearchBar() {
   };
 
   return (
-    <div className="ml-6 flex w-full gap-2 sm:ml-36 sm:gap-4">
-      {/* 드롭다운 버튼 - region */}
-      <Listbox value={selected.region} onChange={handleRegionChange}>
-        <div className="relative mt-4 ">
-          <Listbox.Button className="relative cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:w-[12rem] sm:text-sm">
-            {/* 드롭다운 메뉴 이름 */}
-            <span className="block truncate">{selected.region}</span>
-            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-              {/* 드롭다운 아이콘 */}
-              <div
-                className="max h-5 w-5 text-center text-xl text-gray-400"
-                aria-hidden="true"
-              >
-                <AiOutlineDown />
-              </div>
-            </span>
-          </Listbox.Button>
-
-          {/* 드롭다운 목록 */}
-          <Listbox.Options className="absolute z-10 mt-1 max-h-[25rem] w-[10rem] gap-2 overflow-auto bg-white py-1 text-center text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:w-full sm:text-sm">
-            <div className=" grid grid-cols-2 rounded-lg">
-              {EVENT_REGION_ITEMS.map((value, index) => (
-                <Listbox.Option
-                  key={index}
-                  className={({ active }) =>
-                    `relative grid cursor-pointer select-none px-2 py-4 ${
-                      active
-                        ? 'rounded-lg bg-accent text-white'
-                        : 'text-gray-900'
-                    }`
-                  }
-                  value={value}
+    <div className="container mx-auto  sm:flex  sm:px-20">
+      <div className="ml-8 flex w-full gap-2  sm:m-0 sm:gap-4  sm:pb-4">
+        {/* 드롭다운 버튼 - region */}
+        <Listbox value={selected.region} onChange={handleRegionChange}>
+          <div className="relative mt-4 ">
+            <Listbox.Button className="relative cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:w-[12rem] sm:text-sm">
+              {/* 드롭다운 메뉴 이름 */}
+              <span className="block truncate">{selected.region}</span>
+              <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                {/* 드롭다운 아이콘 */}
+                <div
+                  className="max h-5 w-5 text-center text-xl text-gray-400"
+                  aria-hidden="true"
                 >
-                  {({ selected }) => (
-                    <span
-                      className={`block  ${
-                        selected ? 'font-medium' : 'font-normal'
-                      }`}
-                    >
-                      {value.region}
-                    </span>
-                  )}
-                </Listbox.Option>
-              ))}
-            </div>
-          </Listbox.Options>
-        </div>
-      </Listbox>
+                  <AiOutlineDown />
+                </div>
+              </span>
+            </Listbox.Button>
 
-      {/* 드롭다운 버튼 - state */}
-      <Listbox value={selected.state} onChange={handleStateChange}>
-        <div className="relative mt-4 ">
-          <Listbox.Button className="relative cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:w-[12rem] sm:text-sm">
-            <span className="block truncate">{selected.state}</span>
-            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-              {/* 드롭다운 아이콘 */}
-              <div
-                className="max h-5 w-5 text-center text-xl text-gray-400"
-                aria-hidden="true"
-              >
-                <AiOutlineDown />
+            {/* 드롭다운 목록 */}
+            <Listbox.Options className="absolute z-10 mt-1 max-h-[25rem] w-[10rem] gap-2 overflow-auto bg-white py-1 text-center text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:w-full sm:text-sm">
+              <div className=" grid grid-cols-2 rounded-lg">
+                {EVENT_REGION_ITEMS.map((value, index) => (
+                  <Listbox.Option
+                    key={index}
+                    className={({ active }) =>
+                      `relative grid cursor-pointer select-none px-2 py-4 ${
+                        active
+                          ? 'rounded-lg bg-accent text-white'
+                          : 'text-gray-900'
+                      }`
+                    }
+                    value={value}
+                  >
+                    {({ selected }) => (
+                      <span
+                        className={`block  ${
+                          selected ? 'font-medium' : 'font-normal'
+                        }`}
+                      >
+                        {value.region}
+                      </span>
+                    )}
+                  </Listbox.Option>
+                ))}
               </div>
-            </span>
-          </Listbox.Button>
+            </Listbox.Options>
+          </div>
+        </Listbox>
 
-          {/* 드롭다운 목록 */}
-          <Listbox.Options className="absolute z-10 mt-1 max-h-[25rem] w-[10rem] gap-2 overflow-auto bg-white  py-1 text-center text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:w-full sm:text-sm">
-            <div className=" grid grid-cols-2 rounded-lg">
-              {filteredStates.map((value, index) => (
-                <Listbox.Option
-                  key={index}
-                  className={({ active }) =>
-                    `relative grid cursor-pointer select-none px-2 py-4 ${
-                      active
-                        ? 'rounded-lg bg-accent text-white'
-                        : 'text-gray-900'
-                    }`
-                  }
-                  value={value}
+        {/* 드롭다운 버튼 - state */}
+        <Listbox value={selected.state} onChange={handleStateChange}>
+          <div className="relative mt-4 ">
+            <Listbox.Button className="relative cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:w-[12rem] sm:text-sm">
+              <span className="block truncate">{selected.state}</span>
+              <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                {/* 드롭다운 아이콘 */}
+                <div
+                  className="max h-5 w-5 text-center text-xl text-gray-400"
+                  aria-hidden="true"
                 >
-                  {({ selected }) => (
-                    <span
-                      className={`block  ${
-                        selected ? 'font-medium' : 'font-normal'
-                      }`}
-                    >
-                      {Object.values(value)}
-                    </span>
-                  )}
-                </Listbox.Option>
-              ))}
-            </div>
-          </Listbox.Options>
-        </div>
-      </Listbox>
+                  <AiOutlineDown />
+                </div>
+              </span>
+            </Listbox.Button>
 
-      {/* 드롭다운 버튼 - category */}
-      <Listbox value={selected.category} onChange={handleCategoryChange}>
-        <div className="relative mt-4 ">
-          <Listbox.Button className="relative cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:w-[12rem] sm:text-sm">
-            <span className="block truncate">{selected.category}</span>
-            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-              {/* 드롭다운 아이콘 */}
-              <div
-                className="max h-5 w-5 text-center text-xl text-gray-400"
-                aria-hidden="true"
-              >
-                <AiOutlineDown />
+            {/* 드롭다운 목록 */}
+            <Listbox.Options className="absolute z-10 mt-1 max-h-[25rem] w-[10rem] gap-2 overflow-auto bg-white  py-1 text-center text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:w-full sm:text-sm">
+              <div className=" grid grid-cols-2 rounded-lg">
+                {filteredStates.map((value, index) => (
+                  <Listbox.Option
+                    key={index}
+                    className={({ active }) =>
+                      `relative grid cursor-pointer select-none px-2 py-4 ${
+                        active
+                          ? 'rounded-lg bg-accent text-white'
+                          : 'text-gray-900'
+                      }`
+                    }
+                    value={value}
+                  >
+                    {({ selected }) => (
+                      <span
+                        className={`block  ${
+                          selected ? 'font-medium' : 'font-normal'
+                        }`}
+                      >
+                        {Object.values(value)}
+                      </span>
+                    )}
+                  </Listbox.Option>
+                ))}
               </div>
-            </span>
-          </Listbox.Button>
+            </Listbox.Options>
+          </div>
+        </Listbox>
 
-          {/* 드롭다운 목록 */}
-          <Listbox.Options className="absolute z-10 mt-1 max-h-[25rem] w-[10rem] gap-2 overflow-auto bg-white py-1 text-center text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:w-full sm:text-sm">
-            <div className=" grid grid-cols-2 rounded-lg">
-              {EVENT_CATEGORY_ITEMS.map((value, index) => (
-                <Listbox.Option
-                  key={index}
-                  className={({ active }) =>
-                    `relative grid cursor-pointer select-none px-2 py-4 ${
-                      active
-                        ? 'rounded-lg bg-accent text-white'
-                        : 'text-gray-900'
-                    }`
-                  }
-                  value={value}
+        {/* 드롭다운 버튼 - category */}
+        <Listbox value={selected.category} onChange={handleCategoryChange}>
+          <div className="relative mt-4 ">
+            <Listbox.Button className="relative cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:w-[12rem] sm:text-sm">
+              <span className="block truncate">{selected.category}</span>
+              <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                {/* 드롭다운 아이콘 */}
+                <div
+                  className="max h-5 w-5 text-center text-xl text-gray-400"
+                  aria-hidden="true"
                 >
-                  {({ selected }) => (
-                    <span
-                      className={`block  ${
-                        selected ? 'font-medium' : 'font-normal'
-                      }`}
-                    >
-                      {Object.values(value)}
-                    </span>
-                  )}
-                </Listbox.Option>
-              ))}
-            </div>
-          </Listbox.Options>
-        </div>
-      </Listbox>
+                  <AiOutlineDown />
+                </div>
+              </span>
+            </Listbox.Button>
+
+            {/* 드롭다운 목록 */}
+            <Listbox.Options className="absolute z-10 mt-1 max-h-[25rem] w-[10rem] gap-2 overflow-auto bg-white py-1 text-center text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:w-full sm:text-sm">
+              <div className=" grid grid-cols-2 rounded-lg">
+                {EVENT_CATEGORY_ITEMS.map((value, index) => (
+                  <Listbox.Option
+                    key={index}
+                    className={({ active }) =>
+                      `relative grid cursor-pointer select-none px-2 py-4 ${
+                        active
+                          ? 'rounded-lg bg-accent text-white'
+                          : 'text-gray-900'
+                      }`
+                    }
+                    value={value}
+                  >
+                    {({ selected }) => (
+                      <span
+                        className={`block  ${
+                          selected ? 'font-medium' : 'font-normal'
+                        }`}
+                      >
+                        {Object.values(value)}
+                      </span>
+                    )}
+                  </Listbox.Option>
+                ))}
+              </div>
+            </Listbox.Options>
+          </div>
+        </Listbox>
+      </div>
+      <div className="ml-8 mt-4 w-28 sm:ml-0 sm:w-36">
+        <button
+          onClick={resetList}
+          className="flex h-10 w-full justify-center rounded-md border-2 border-accent bg-white px-2 py-2 text-sm font-bold text-accent ring-subTextAndBorder ring-offset-2 transition hover:opacity-80 focus:ring-2 active:scale-95 disabled:pointer-events-none disabled:opacity-30 sm:h-10 sm:py-1.5 sm:text-base"
+        >
+          <HiArrowPath className="mr-1 text-xl sm:text-2xl" />
+          조건 초기화
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/data/address.ts
+++ b/src/data/address.ts
@@ -1,0 +1,64 @@
+interface IAdress {
+  [key: string]: string;
+}
+
+export const EVENT_REGION_ITEMS = [
+  { region: '전체' },
+  { region: '서울' },
+  { region: '경기' },
+  { region: '인천' },
+  { region: '부산' },
+  { region: '대전' },
+  { region: '대구' },
+  { region: '울산' },
+  { region: '세종' },
+  { region: '울산' },
+  { region: '광주' },
+  { region: '강원' },
+  { region: '충북' },
+  { region: '충남' },
+  { region: '경북' },
+  { region: '경남' },
+  { region: '전북' },
+  { region: '전남' },
+];
+
+export const EVENT_STATE_ITEMS: IAdress[] = [
+  { 전체: '전체' },
+  { 서울: '강남' },
+  { 서울: '강동' },
+  { 서울: '강북' },
+  { 서울: '강서' },
+  { 서울: '관악' },
+  { 서울: '광진' },
+  { 서울: '구로' },
+  { 서울: '금천' },
+  { 서울: '노원' },
+  { 서울: '도봉' },
+  { 서울: '동대문' },
+  { 서울: '동작' },
+  { 서울: '마포' },
+  { 서울: '서대문' },
+  { 서울: '서초' },
+  { 서울: '성동' },
+  { 서울: '성북' },
+  { 서울: '송파' },
+  { 서울: '양천' },
+  { 서울: '영등포' },
+  { 서울: '용산' },
+  { 서울: '은평' },
+  { 서울: '종로' },
+  { 서울: '중구' },
+  { 서울: '중랑' },
+  { 경기: '고양' },
+];
+
+export const EVENT_CATEGORY_ITEMS: IAdress[] = [
+  { 전체: '전체' },
+  { catergory: '레저' },
+  { catergory: '패션' },
+  { catergory: '식품' },
+  { catergory: '스포츠' },
+  { catergory: '아트' },
+  { catergory: '뷰티' },
+];

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -51,3 +51,6 @@ export const PASSWORD_REGEX = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
 // 페이지네이션 상수
 export const ITEMS_COUNT_PER_COMMUNITY_PAGE: number = 10;
 export const PAGE_RANGE_DISPLAY: number = 5;
+
+// 전체 이벤트 조회
+export const COUNT_PER_EVENTS_PAGE = 12;

--- a/src/routes/events/Events.tsx
+++ b/src/routes/events/Events.tsx
@@ -1,11 +1,12 @@
-import Banner from '@/components/Banner';
+import { RecoilRoot } from 'recoil';
 import EventList from '@/components/events/EventList';
+import EventSearchBar from '@/components/events/EventSearchBar';
 
 export default function Events() {
   return (
-    <>
-      <Banner />
+    <RecoilRoot>
+      <EventSearchBar />
       <EventList />
-    </>
+    </RecoilRoot>
   );
 }

--- a/src/states/AdressState.ts
+++ b/src/states/AdressState.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+import { TAdressType } from '@/types/TAdressType';
+
+export const AdressState = atom<TAdressType>({
+  key: 'AdressState',
+  default: {
+    region: '지역',
+    state: '시/군/구',
+    category: '카테고리',
+  },
+});

--- a/src/types/TAdressType.ts
+++ b/src/types/TAdressType.ts
@@ -1,0 +1,5 @@
+export type TAdressType = {
+  region?: string;
+  state?: string;
+  category?: string;
+};


### PR DESCRIPTION
## ✨ 기능명
![image](https://github.com/FC-MINI-4/attendance-front/assets/83483378/e0743d9f-8d22-422d-af30-0d9a1e15d9a1)

![image](https://github.com/FC-MINI-4/attendance-front/assets/83483378/d540ec3b-3505-4310-b930-9f7f0815925d)

### 📝 작업내용

- 주소 및 카테고리 기반으로 등록된 행사 조회할 수 있도록 검색 메뉴 바 생성했습니다.
- 광역시에 따라 자치구가 다르게 나오도록 하였습니다.
- 아직 검색까지 구현하지 못했고 UI만 우선 잡아놓았습니다.

### 🐞 관련 이슈

### 궁금한 사항 또는 공유할 사항

